### PR TITLE
mac support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pip==23.3; sys_platform == 'darwin'
 wheel; sys_platform == 'darwin'
 PyYAML; sys_platform == 'darwin'
 numpy==1.23.5
-requests==2.32.0
+requests
 tqdm
 wget
 pydantic==2.8.2
@@ -42,7 +42,7 @@ tensorboard
 gradio==4.43.0
 
 # Miscellaneous utilities
-certifi==2024.7.4; sys_platform == 'darwin'
+certifi; sys_platform == 'darwin'
 antlr4-python3-runtime==4.8; sys_platform == 'darwin'
 ffmpy==0.3.1
 tensorboardX

--- a/start.js
+++ b/start.js
@@ -6,6 +6,9 @@ module.exports = {
       method: "shell.run",
       params: {
         venv: "env",
+        env: {
+          PYTORCH_ENABLE_MPS_FALLBACK: 1
+        },
         path: "applio",
         message: [
           "python app.py",


### PR DESCRIPTION
1. The requests and certifi dependencies fail to install on macs because of version conflicts. just loosen it up by not specifying the versions.
2. Add `PYTORCH_ENABLE_MPS_FALLBACK=1` otherwise it fails because it uses some torch features not supported by MPS